### PR TITLE
Feat/7123 add databricks lib version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "stacks-data"
-version = "0.2.1"
+version = "0.3.0"
 description = "A suite of utilities to support data engineering workloads within an Ensono Stacks data platform."
 authors = [
     "Andy Durkan <andy.durkan@ensono.com>",

--- a/stacks/data/generate/template_config.py
+++ b/stacks/data/generate/template_config.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel, Field
 import yaml
 from abc import ABC, abstractmethod
 
+from stacks.data.utils import get_latest_package_version
+
 
 class DataSourceType(Enum):
     """Enum containing supported data source types."""
@@ -54,6 +56,11 @@ class WorkloadConfigBaseModel(BaseModel, ABC):
     )
     default_arm_deployment_mode: Optional[str] = Field(
         default="Incremental", description="Deployment mode for terraform."
+    )
+    stacks_data_library_version: str = Field(
+        default=get_latest_package_version("stacks-data"),
+        description="Version of the stacks-data Python library to use on the job cluster, e.g. 0.3.0.",
+        regex=r"\d+\.\d+\.\d+.*",
     )
 
     @classmethod

--- a/stacks/data/generate/template_config.py
+++ b/stacks/data/generate/template_config.py
@@ -57,9 +57,9 @@ class WorkloadConfigBaseModel(BaseModel, ABC):
     default_arm_deployment_mode: Optional[str] = Field(
         default="Incremental", description="Deployment mode for terraform."
     )
-    stacks_data_library_version: str = Field(
+    stacks_data_package_version: str = Field(
         default=get_latest_package_version("stacks-data"),
-        description="Version of the stacks-data Python library to use on the job cluster, e.g. 0.3.0.",
+        description="Version of the stacks-data Python package to use on the job cluster, e.g. 0.3.0.",
         regex=r"\d+\.\d+\.\d+.*",
     )
 

--- a/stacks/data/generate/templates/ingest/ingest_template_DQ/data_factory/pipelines/arm_template.json.jinja
+++ b/stacks/data/generate/templates/ingest/ingest_template_DQ/data_factory/pipelines/arm_template.json.jinja
@@ -279,7 +279,7 @@
                             "libraries": [
                                 {
                                     "pypi": {
-                                        "package": "stacks-data"
+                                        "package": "stacks-data=={{ stacks_data_package_version }}"
                                     }
                                 }
                             ]

--- a/stacks/data/generate/templates/processing/processing_template/data_factory/pipelines/arm_template.json.jinja
+++ b/stacks/data/generate/templates/processing/processing_template/data_factory/pipelines/arm_template.json.jinja
@@ -47,7 +47,7 @@
                             "libraries": [
                                 {
                                     "pypi": {
-                                        "package": "stacks-data"
+                                        "package": "stacks-data=={{ stacks_data_package_version }}"
                                     }
                                 }
                             ]

--- a/stacks/data/generate/templates/processing/processing_template_DQ/data_factory/pipelines/arm_template.json.jinja
+++ b/stacks/data/generate/templates/processing/processing_template_DQ/data_factory/pipelines/arm_template.json.jinja
@@ -49,7 +49,7 @@
                             "libraries": [
                                 {
                                     "pypi": {
-                                        "package": "stacks-data"
+                                        "package": "stacks-data=={{ stacks_data_package_version }}"
                                     }
                                 }
                             ]
@@ -87,7 +87,7 @@
                             "libraries": [
                                 {
                                     "pypi": {
-                                        "package": "stacks-data"
+                                        "package": "stacks-data=={{ stacks_data_package_version }}"
                                     }
                                 }
                             ]

--- a/stacks/data/utils.py
+++ b/stacks/data/utils.py
@@ -124,8 +124,7 @@ def load_configs_as_list(path: str) -> list[dict]:
 def get_latest_package_version(package_name: str) -> str:
     """Retrieve the latest version of a package from PyPI (Python Package Index).
 
-    This function makes a HTTP request to PyPI to fetch metadata about the specified package,
-    and returns its latest version.
+    Makes a HTTP request to PyPI to fetch metadata about the specified package, and returns its latest version.
 
     Args:
         package_name (str): A PyPI package name.

--- a/tests/data/template_config/test_config_ingest_full.yml
+++ b/tests/data/template_config/test_config_ingest_full.yml
@@ -1,0 +1,20 @@
+dataset_name: test_dataset
+pipeline_description: Pipeline for testing ingest, full config
+data_source_type: azure_sql
+key_vault_linked_service_name: test_keyvault
+data_source_password_key_vault_secret_name: test_password
+data_source_connection_string_variable_name: test_connection_string
+ado_variable_groups_nonprod:
+  - nonprod_test_group
+ado_variable_groups_prod:
+  - prod_group
+bronze_container: test_raw
+default_arm_deployment_mode: Incremental
+stacks_data_library_version: 0.1.2
+window_start_default: "2010-01-01"
+window_end_default: "2010-01-31"
+trigger_start: "2010-01-01T00:00:00Z"
+trigger_end: "2011-12-31T23:59:59Z"
+trigger_frequency: "Month"
+trigger_interval: 1
+trigger_delay: "02:00:00"

--- a/tests/data/template_config/test_config_ingest_full.yml
+++ b/tests/data/template_config/test_config_ingest_full.yml
@@ -10,7 +10,7 @@ ado_variable_groups_prod:
   - prod_group
 bronze_container: test_raw
 default_arm_deployment_mode: Incremental
-stacks_data_library_version: 0.1.2
+stacks_data_package_version: 0.1.2
 window_start_default: "2010-01-01"
 window_end_default: "2010-01-31"
 trigger_start: "2010-01-01T00:00:00Z"

--- a/tests/data/template_config/test_config_ingest_invalid.yml
+++ b/tests/data/template_config/test_config_ingest_invalid.yml
@@ -9,4 +9,4 @@ ado_variable_groups_nonprod:
 ado_variable_groups_prod:
   - prod_group
 bronze_container: test_raw
-stacks_data_library_version: invalid
+stacks_data_package_version: invalid

--- a/tests/data/template_config/test_config_ingest_invalid.yml
+++ b/tests/data/template_config/test_config_ingest_invalid.yml
@@ -1,5 +1,5 @@
 dataset_name: test_dataset
-pipeline_description: Pipeline for testing
+pipeline_description: Pipeline for testing ingest, invalid config
 data_source_type: azure_sql
 key_vault_linked_service_name: test_keyvault
 data_source_password_key_vault_secret_name: test_password
@@ -9,3 +9,4 @@ ado_variable_groups_nonprod:
 ado_variable_groups_prod:
   - prod_group
 bronze_container: test_raw
+stacks_data_library_version: invalid

--- a/tests/data/template_config/test_config_ingest_minimal.yml
+++ b/tests/data/template_config/test_config_ingest_minimal.yml
@@ -1,5 +1,5 @@
 dataset_name: test_dataset
-pipeline_description: Pipeline for testing overwritten
+pipeline_description: Pipeline for testing ingest, minimal config
 data_source_type: azure_sql
 key_vault_linked_service_name: test_keyvault
 data_source_password_key_vault_secret_name: test_password
@@ -9,3 +9,4 @@ ado_variable_groups_nonprod:
 ado_variable_groups_prod:
   - prod_group
 bronze_container: test_raw
+stacks_data_library_version: 0.1.2

--- a/tests/data/template_config/test_config_ingest_minimal.yml
+++ b/tests/data/template_config/test_config_ingest_minimal.yml
@@ -9,4 +9,4 @@ ado_variable_groups_nonprod:
 ado_variable_groups_prod:
   - prod_group
 bronze_container: test_raw
-stacks_data_library_version: 0.1.2
+stacks_data_package_version: 0.1.2

--- a/tests/data/template_config/test_config_process_full.yml
+++ b/tests/data/template_config/test_config_process_full.yml
@@ -1,0 +1,8 @@
+pipeline_name: test_pipeline
+pipeline_description: Pipeline for testing process, full config
+ado_variable_groups_nonprod:
+  - nonprod_test_group
+ado_variable_groups_prod:
+  - prod_group
+default_arm_deployment_mode: Incremental
+stacks_data_library_version: 0.1.2

--- a/tests/data/template_config/test_config_process_full.yml
+++ b/tests/data/template_config/test_config_process_full.yml
@@ -5,4 +5,4 @@ ado_variable_groups_nonprod:
 ado_variable_groups_prod:
   - prod_group
 default_arm_deployment_mode: Incremental
-stacks_data_library_version: 0.1.2
+stacks_data_package_version: 0.1.2

--- a/tests/data/template_config/test_config_process_invalid.yml
+++ b/tests/data/template_config/test_config_process_invalid.yml
@@ -1,0 +1,8 @@
+pipeline_name: test_pipeline
+pipeline_description: Pipeline for testing process, invalid config
+ado_variable_groups_nonprod:
+  - nonprod_test_group
+ado_variable_groups_prod:
+  - prod_group
+default_arm_deployment_mode: Incremental
+stacks_data_library_version: invalid

--- a/tests/data/template_config/test_config_process_invalid.yml
+++ b/tests/data/template_config/test_config_process_invalid.yml
@@ -5,4 +5,4 @@ ado_variable_groups_nonprod:
 ado_variable_groups_prod:
   - prod_group
 default_arm_deployment_mode: Incremental
-stacks_data_library_version: invalid
+stacks_data_package_version: invalid

--- a/tests/data/template_config/test_config_process_minimal.yml
+++ b/tests/data/template_config/test_config_process_minimal.yml
@@ -1,5 +1,5 @@
 pipeline_name: test_pipeline
-pipeline_description: Pipeline for testing
+pipeline_description: Pipeline for testing process, minimal config
 ado_variable_groups_nonprod:
   - nonprod_test_group
 ado_variable_groups_prod:

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -49,12 +49,13 @@ def test_cli(function, config, dq_opt):
 )
 def test_cli_invalid(function, config, dq_opt):
     runner = CliRunner()
+    test_config_file = "test_config.yml"
     with open(config, "r") as file:
         config_dict = yaml.safe_load(file)
 
     with runner.isolated_filesystem():
-        with open("test_config_ingest.yml", "w") as f:
+        with open(test_config_file, "w") as f:
             f.write(yaml.dump(config_dict))
 
-        result = runner.invoke(function, ["--config", "test_config_ingest.yml", dq_opt])
+        result = runner.invoke(function, ["--config", test_config_file, dq_opt])
         assert isinstance(result.exception, ValidationError)

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -1,38 +1,60 @@
-from click.testing import CliRunner
+import pytest
 import yaml
+
+from click.testing import CliRunner
+from pydantic import ValidationError
 from stacks.data.cli.datastacks_cli import ingest, processing
 
 
 TEST_CONFIG_DIRECTORY = "tests/data/template_config/"
-TEST_CONFIG_INGEST = TEST_CONFIG_DIRECTORY + "test_config_ingest.yml"
-TEST_CONFIG_PROCESS = TEST_CONFIG_DIRECTORY + "test_config_process.yml"
+TEST_CONFIG_INGEST_MINIMAL = TEST_CONFIG_DIRECTORY + "test_config_ingest_minimal.yml"
+TEST_CONFIG_INGEST_FULL = TEST_CONFIG_DIRECTORY + "test_config_ingest_full.yml"
+TEST_CONFIG_INGEST_INVALID = TEST_CONFIG_DIRECTORY + "test_config_ingest_invalid.yml"
+TEST_CONFIG_PROCESS_MINIMAL = TEST_CONFIG_DIRECTORY + "test_config_process_minimal.yml"
+TEST_CONFIG_PROCESS_FULL = TEST_CONFIG_DIRECTORY + "test_config_process_full.yml"
+TEST_CONFIG_PROCESS_INVALID = TEST_CONFIG_DIRECTORY + "test_config_process_invalid.yml"
 
 
-def test_cli_ingest():
+@pytest.mark.parametrize(
+    "function,config,dq_opt",
+    [
+        (ingest, TEST_CONFIG_INGEST_MINIMAL, "--no-data-quality"),
+        (ingest, TEST_CONFIG_INGEST_MINIMAL, "--data-quality"),
+        (processing, TEST_CONFIG_PROCESS_MINIMAL, "--no-data-quality"),
+        (processing, TEST_CONFIG_PROCESS_FULL, "--data-quality"),
+    ],
+)
+def test_cli(function, config, dq_opt):
     runner = CliRunner()
-    dq_options = ["--no-data-quality", "--data-quality"]
-    with open(TEST_CONFIG_INGEST, "r") as file:
+    test_config_file = "test_config.yml"
+    with open(config, "r") as file:
+        config_dict = yaml.safe_load(file)
+
+    with runner.isolated_filesystem():
+        with open(test_config_file, "w") as f:
+            f.write(yaml.dump(config_dict))
+
+        result = runner.invoke(function, ["--config", test_config_file, dq_opt])
+        assert result.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    "function,config,dq_opt",
+    [
+        (ingest, TEST_CONFIG_INGEST_INVALID, "--no-data-quality"),
+        (ingest, TEST_CONFIG_INGEST_INVALID, "--data-quality"),
+        (processing, TEST_CONFIG_PROCESS_INVALID, "--no-data-quality"),
+        (processing, TEST_CONFIG_PROCESS_INVALID, "--data-quality"),
+    ],
+)
+def test_cli_invalid(function, config, dq_opt):
+    runner = CliRunner()
+    with open(config, "r") as file:
         config_dict = yaml.safe_load(file)
 
     with runner.isolated_filesystem():
         with open("test_config_ingest.yml", "w") as f:
             f.write(yaml.dump(config_dict))
 
-        for dq_option in dq_options:
-            result = runner.invoke(ingest, ["--config", "test_config_ingest.yml", dq_option])
-            assert result.exit_code == 0
-
-
-def test_cli_processing():
-    runner = CliRunner()
-    dq_options = ["--no-data-quality", "--data-quality"]
-    with open(TEST_CONFIG_PROCESS, "r") as file:
-        config_dict = yaml.safe_load(file)
-
-    with runner.isolated_filesystem():
-        with open("test_config_process.yml", "w") as f:
-            f.write(yaml.dump(config_dict))
-
-        for dq_option in dq_options:
-            result = runner.invoke(processing, ["--config", "test_config_process.yml", dq_option])
-            assert result.exit_code == 0
+        result = runner.invoke(function, ["--config", "test_config_ingest.yml", dq_opt])
+        assert isinstance(result.exception, ValidationError)

--- a/tests/unit/generate/conftest.py
+++ b/tests/unit/generate/conftest.py
@@ -1,7 +1,4 @@
 TEST_CONFIG_DIRECTORY = "tests/data/template_config/"
-TEST_CONFIG_INGEST = TEST_CONFIG_DIRECTORY + "test_config_ingest.yml"
-TEST_CONFIG_INGEST_OVERWRITE = TEST_CONFIG_DIRECTORY + "test_config_ingest_overwrite.yml"
-TEST_CONFIG_PROCESS = TEST_CONFIG_DIRECTORY + "test_config_process.yml"
 
 INGEST_EXPECTED_FILES = [
     "config/ingest_sources/ingest_config.json",

--- a/tests/unit/generate/test_data_workloads.py
+++ b/tests/unit/generate/test_data_workloads.py
@@ -39,7 +39,7 @@ def test_render_template_components(tmp_path):
         "ado_variable_groups_nonprod": ["nonprod_test_group"],
         "ado_variable_groups_prod": ["prod_group"],
         "bronze_container": "test_raw",
-        "stacks_data_library_version": "0.1.2",
+        "stacks_data_package_version": "0.1.2",
     }
     config = IngestWorkloadConfigModel(**config_dict)
 


### PR DESCRIPTION
#### 📲 What

Add the stacks-data package version as a config item and add into the ADF pipeline templates, so this gets specified in the Databricks job configuration.

#### 🤔 Why

We need to ensure that when workloads are generated, a specific version of the stacks-data package is being installed to ensure that jobs will run consistently in the event of changes to the package.

#### 🛠 How

- Add additional generation config item: `stacks_data_package_version`
- Add this into the ADF pipeline templates against the stacks-data package details in the Databricks job
- Add a function `get_latest_package_version` which will return the latest version of the package, which can be used as a default value
- Add additional unit tests

#### 👀 Evidence

New workloads generated contain the package specified in the ADF Databricks activity 9e.g. `stacks-data==0.1.2`

#### 🕵️ How to test

Generate and run new workloads. Ensure they pick up the version of the package specified.

#### ✅ Acceptance criteria Checklist

- [x] Code peer reviewed?
- [x] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [x] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
